### PR TITLE
Add disable on screensaver ability

### DIFF
--- a/script.ambibox/resources/language/English/strings.xml
+++ b/script.ambibox/resources/language/English/strings.xml
@@ -32,6 +32,8 @@
   <string id="32022">Backlight on</string>
   <string id="32023">Show menu when playing</string>
   <string id="32024">Do not show menu when playing</string>
+  <string id="32050">Disable on screensaver</string>
+  <string id="32051">Last profile</string>
 
   <!-- Notification -->
   <string id="32030">Connected to AmbiBox</string>

--- a/script.ambibox/resources/language/Russian/strings.xml
+++ b/script.ambibox/resources/language/Russian/strings.xml
@@ -32,6 +32,8 @@
   <string id="32022">Включить подсветку</string>
   <string id="32023">Показать меню при воспроизведении</string>
   <string id="32024">Не показывать меню при воспроизведении</string>
+  <string id="32050">Отключите на заставке</string>
+  <string id="32051">Последнее профиль</string>
 
   <!-- Notification -->
   <string id="32030">Подключение к AmbiBox</string>

--- a/script.ambibox/resources/settings.xml
+++ b/script.ambibox/resources/settings.xml
@@ -19,6 +19,8 @@
     <setting id="video_choice" type ="enum" label="32025" lvalues="32026|32027|32028|32029" default="2" />
     <setting id="video_profile" type="text" label="32014" default="default" subsetting="true" enable="eq(-1,0)"  />
     <setting id="directXBMC_enable" type="bool" label="32017" default="true" subsetting="true" enable="!eq(-2,3)" />
+    <setting id="disable_on_screensaver" type="bool" label="32050" value="true" default="true" />
+    <setting id="last_profile" type="text" label="32051" value="true" default="default" visible="false" />
     <setting id="show_menu" type="bool" label="32023" value="true" default="true" visible="false" />
 
 


### PR DESCRIPTION
- Screensaver detection using xbmc.Monitor
- 2 new settings (disable_on_screensaver|last_profile)
- CapturePlayer:setProfile sets last_profile to store the profile last used so script knows which profile to switch back to
- I used Google Translate to get the Russian translations, so they may be incorrect
